### PR TITLE
Added tresholds

### DIFF
--- a/ASCII.py
+++ b/ASCII.py
@@ -12,24 +12,29 @@ cap = cv.VideoCapture(0)
 cap.set(cv.CAP_PROP_FRAME_WIDTH, 35)
 cap.set(cv.CAP_PROP_FRAME_HEIGHT, 20)
 
+
 def map_color_value(old_value):
     return math.floor(((old_value - 0) / (255 - 0)) * (len(pixel_map)-1 - 0) + 0)
+
 
 for i in range(256):
     pixel_hash.append(pixel_map[map_color_value(i)])
 
-for i in range(10):
+print(pixel_hash)
+for i in range(5):
 
     ret, image = cap.read()
     if image is None:
         break
 
     image_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
+    ret, thresholded = cv.threshold(image_gray, 10 , 255, cv.THRESH_BINARY)
+    # ret, thresholded = cv.threshold(image_gray, 10, 255, cv.THRESH_TRUNC)
 
-    for i,row in enumerate(image_gray):
-        for j,column in enumerate(row):
-            r,g,b = image[i][j]
-            #print(pixel_map[map_color_value(column)], end="")
+    for i, row in enumerate(image_gray):
+        for j, column in enumerate(row):
+            r, g, b = image[i][j]
+            # print(pixel_map[map_color_value(column)], end="")
             print(f"\x1b[38;2;{r};{g};{b}m{pixel_hash[column]}\x1b[0m", end='')
 
         print()


### PR DESCRIPTION
Goal was to group similar pixels so that the image resolution can be reduced. By this the generation time for each image is much quicker

mapping from 255 -> 10. There is still some scope in improving the performance by choosing a different threshold type.