### PR TITLE
Creating Thresholds for optimising performance

### DIFF
--- a/ASCII.py
+++ b/ASCII.py
@@ -12,24 +12,29 @@ cap = cv.VideoCapture(0)
 cap.set(cv.CAP_PROP_FRAME_WIDTH, 35)
 cap.set(cv.CAP_PROP_FRAME_HEIGHT, 20)
 
+
 def map_color_value(old_value):
     return math.floor(((old_value - 0) / (255 - 0)) * (len(pixel_map)-1 - 0) + 0)
+
 
 for i in range(256):
     pixel_hash.append(pixel_map[map_color_value(i)])
 
-for i in range(10):
+print(pixel_hash)
+for i in range(5):
 
     ret, image = cap.read()
     if image is None:
         break
 
     image_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
+    ret, thresholded = cv.threshold(image_gray, 10 , 255, cv.THRESH_BINARY)
+    # ret, thresholded = cv.threshold(image_gray, 10, 255, cv.THRESH_TRUNC)
 
-    for i,row in enumerate(image_gray):
-        for j,column in enumerate(row):
-            r,g,b = image[i][j]
-            #print(pixel_map[map_color_value(column)], end="")
+    for i, row in enumerate(image_gray):
+        for j, column in enumerate(row):
+            r, g, b = image[i][j]
+            # print(pixel_map[map_color_value(column)], end="")
             print(f"\x1b[38;2;{r};{g};{b}m{pixel_hash[column]}\x1b[0m", end='')
 
         print()

--- a/ASCII.py
+++ b/ASCII.py
@@ -27,7 +27,7 @@ for i in range(10):
         break
 
     image_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
-    ret, thresholded = cv.threshold(image_gray, 10 , 255, cv.THRESH_BINARY)
+    ret, thresholded = cv.threshold(image_gray, 5 , 255, cv.THRESH_TOZERO_INV)
 
     for i, row in enumerate(image_gray):
         for j, column in enumerate(row):

--- a/ASCII.py
+++ b/ASCII.py
@@ -28,7 +28,6 @@ for i in range(10):
 
     image_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
     ret, thresholded = cv.threshold(image_gray, 10 , 255, cv.THRESH_BINARY)
-    # ret, thresholded = cv.threshold(image_gray, 10, 255, cv.THRESH_TRUNC)
 
     for i, row in enumerate(image_gray):
         for j, column in enumerate(row):

--- a/ASCII.py
+++ b/ASCII.py
@@ -20,8 +20,7 @@ def map_color_value(old_value):
 for i in range(256):
     pixel_hash.append(pixel_map[map_color_value(i)])
 
-print(pixel_hash)
-for i in range(5):
+for i in range(10):
 
     ret, image = cap.read()
     if image is None:

--- a/ASCII.py
+++ b/ASCII.py
@@ -29,7 +29,7 @@ for i in range(10):
     image_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
     ret, thresholded = cv.threshold(image_gray, 5 , 255, cv.THRESH_TOZERO_INV)
 
-    for i, row in enumerate(image_gray):
+    for i, row in enumerate(thresholded):
         for j, column in enumerate(row):
             r, g, b = image[i][j]
             # print(pixel_map[map_color_value(column)], end="")


### PR DESCRIPTION
Goal was to group similar pixels so that the image resolution can be reduced. By this the generation time for each image is much quicker

mapping from 255 -> 10. There is still some scope in improving the performance by choosing a different threshold type.

Changed the thresholding technique to `cv.THRESH_TOZERO_INV` make image render quicker